### PR TITLE
Don't pass along credential info

### DIFF
--- a/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
+++ b/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
@@ -1424,7 +1424,7 @@ ol.proj.addProjection(createEPSG4326Proj('EPSG:4326:LONLAT', 'enu'));
                     layer.getSource().setState(ol.source.State.LOADING)
 
                     return fetch(url + (url.indexOf('?') >= 0 ? '&' : '?') + kvp2string(queryParams),
-                        {method:'GET', credentials: 'include'}
+                        {method:'GET'}
                     ).then(
                         function (response) {
                             return response.text();


### PR DESCRIPTION
This causes problems with sites that have wildcard CORS set up:
"The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'."

So I was just wondering if there was an overt reason for setting this up this way, or if we can change it, with this provocative commit/PR :-)